### PR TITLE
Migrate to pnpm@11

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,6 @@
   },
   "trustedDependencies": [
     "@rocicorp/zero-sqlite3"
-  ]
+  ],
+  "packageManager": "pnpm@11.1.3"
 }


### PR DESCRIPTION
## Summary
- Replaces \`package-lock.json\` with \`pnpm-lock.yaml\`
- Adds \`"packageManager": "pnpm@11.1.3"\` to \`package.json\`
- Removes legacy \`pnpm\` field from \`package.json\` (settings moved to \`pnpm-workspace.yaml\` in pnpm@11, but omitted here for Vercel compatibility)

## Test plan
- [ ] \`pnpm install\` runs cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)