### PR TITLE
chore: add 7-day bun release-age cooldown

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[install]
+# Supply-chain hardening: only install npm package versions published
+# at least 7 days ago (604800 seconds), so freshly-compromised releases
+# are likely caught/yanked before we pull them.
+# https://snyk.io/blog/tanstack-npm-packages-compromised/
+minimumReleaseAge = 604800


### PR DESCRIPTION
Adds \`bunfig.toml\` with \`[install] minimumReleaseAge = 604800\` (7 days, in seconds) — Snyk Step 6 / TanStack advisory.

zslack installs via **bun** (\`bun.lock\`); bun has **no** default release-age cooldown. This makes resolution only select versions published **>= 7 days ago**, the window in which most malicious releases get caught and yanked.

- bun units are **seconds** (≠ npm days / pnpm minutes); 604800 = 7d.
- bun also supports \`minimumReleaseAgeExcludes\` if a specific dep ever needs to bypass the window.
- Note: the \`packageManager: pnpm@11.1.3\` field in package.json is vestigial from an earlier migration; this repo actually uses bun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)